### PR TITLE
Update 0-front-matter.markdown

### DIFF
--- a/docs/0-front-matter.markdown
+++ b/docs/0-front-matter.markdown
@@ -85,10 +85,10 @@ This work was supported by the Advanced Research Projects Agency of
 the Department of Defense and was monitored by the Office of Naval 
 Research under contract N00014-75-C-0661.
 
-This document was prepared using [the PUB system]
-(http://www.nomodes.com/pub_manual.html) (originally from the Stanford
-Artificial Intelligence Laboratory) and printed on the Xerox Graphics
-Printer of the M.I.T. Artificial Intelligence Laboratory.
+This document was prepared using [the PUB
+system](http://www.nomodes.com/pub_manual.html) (originally from the
+Stanford Artificial Intelligence Laboratory) and printed on the Xerox
+Graphics Printer of the M.I.T. Artificial Intelligence Laboratory.
 
 ## Foreword
 


### PR DESCRIPTION
I noticed that the link to the PUB system wasn't being rendered as such but as text on the GitHub website. It seems to be due to line wrapping. This seems to fix that.