### PR TITLE
Fix typo in name

### DIFF
--- a/docs/appendix-5-initial-settings.md
+++ b/docs/appendix-5-initial-settings.md
@@ -2,7 +2,7 @@
 
 The various switches and useful variables in MDL are initially set up with the following values:
 
-    <ACTIVAIE-CHARS <STRING <ASCII 7> <ASCII 19> <ASCII 15>>>
+    <ACTIVATE-CHARS <STRING <ASCII 7> <ASCII 19> <ASCII 15>>>
                           ;"Tenex and Tops-20 versions only"
     <DECL-CHECK T>
     <UNASSIGN <GUNASSIGN DEV>>


### PR DESCRIPTION
It's difficult to tell in the scanned image, but this looks like it should be ACTIVATE, not ACTIVAIE. The spelling agrees with other sections (e.g. docs/appendix-8-name-index.md and docs/21-interrupts.md).